### PR TITLE
update hyper-v installation instructions to stem vm

### DIFF
--- a/vms/Hyper-V.md
+++ b/vms/Hyper-V.md
@@ -1,17 +1,37 @@
 # Setting up VMs using Hyper-V
 
-* This documentation on the Hyper-V site is pretty good
-
+External Links
 * [Hyper-V Overview ](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/)
+* [Introduction to Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/)
+* [Install Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
+* [Create a Virtual Machine with Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/quick-create-virtual-machine)
 
-    * [Introduction to Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/)
+- - - 
+- - - 
 
+# Setting up a "Stem" or "Base" VM Image
 
-    * [Install Hyper-V on Windows 10](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/enable-hyper-v)
+* Unlike VirtualBox, there is still no simple way to clone a Hyper-V VM. So it's best to follow/repeat these steps once for each VM that you want to set up.
 
+* These instructions were developed with Hyper-V Manager Version 10.0.18362.1 on Windows Version 10.0.18362 Build 18362.
 
-    * [Create a Virtual Machine with Hyper-V](https://docs.microsoft.com/en-us/virtualization/hyper-v-on-windows/quick-start/quick-create-virtual-machine)
-
-* > To Do: Document the Hyper-V specific details for setting up the "Stem" VMs
-
+* Steps
+  * Under the Actions pane (on the upper-right side), select New -> Virtual Machine
+  * Under Specify Name and Location
+    * Name: stem1 (or stem 2, or stem 3, etc)
+  * Under Specify Generation, select Generation 1
+  * Under Assign Memory, select 4096, and enable "Use Dynamic Memory for this virtual machine"
+  * Under Configure Networking, select Default Switch
+  * Under Connect Virtual Hard Disk
+    * Select Create a virtual disk
+    * Name: stem1.vhdx
+    * Size: 20 GB
+  * Under Installation Option
+    * Select Install an operating system from a bootable CD/DVD-ROM
+    * Image File (.iso): Ubuntu 18.04 Server .iso file (e.g. ubuntu-18.04.3-live-server-amd64.iso)
+  * Click Finish
+  * Hyper-V Manager will now show the new stem VM, but it will be powered off
+    * Right-click the VM and click Connect
+    * Click Start and complete the Ubuntu installation process
+    
 


### PR DESCRIPTION
Hi Gerry, I have posted notes on Hyper-V setup.

These instructions use the Default Switch, so there are no instructions to set up a switch before setting up the VMs. I think the Default Switch will work fine for our purposes, but if not, then we can revise these instructions. It is easy to swap out a VM's switch as long as the VM is turned off.